### PR TITLE
feat: support Excel writer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ local: build  ## Run some tests on local machine
 	./bin/cntblank --output-without-header --output-meta --output-format=csv --output=_build/t.txt testdata/addrcode_jp.xlsx testdata/prefecture_jp.tsv
 	./bin/cntblank --output-format=json --output=_build/t.json testdata/addrcode_jp.xlsx
 	./bin/cntblank --output-format=html --output=_build/t.html testdata/addrcode_jp.xlsx --input-delimiter=, testdata/elementary_school_teacher_ja.csv
+	./bin/cntblank --output=_build/t.xlsx testdata/addrcode_jp.xlsx --input-delimiter=, testdata/elementary_school_teacher_ja.csv
 
 dist: clean darwin linux windows  ## Build distribution binaries
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Count blank cells on text-based tabular data.
 
 Short examples:
 
+It can parse tab-delimited data file, which contains only 2 columns.
+
 ```bash
 $ ./cntblank --output-meta testdata/prefecture_jp.tsv
 INFO[0000] start parsing with 2 columns.                 path=testdata/prefecture_jp.tsv
@@ -19,7 +21,8 @@ seq     Name    #Blank  %Blank  MinLength       MaxLength       #Int    #Float  
 2       都道府県        0       0.0000  3       4
 ```
 
-Since file argument is optional, it accepts standard input.
+Since it accepts standard input when no file arguments are given,
+you can pipe another output such as downloaded contents.
 
 ```bash
 $ curl -sL https://raw.githubusercontent.com/datasets/language-codes/master/data/ietf-language-tags.csv |
@@ -33,7 +36,7 @@ seq            Name           #Blank         %Blank         MinLength      MaxLe
 6              file           0              0.0000         6              18
 ```
 
-Also accepts Excel file whose extension is ".xlsx".
+It also accepts Microsoft Excel file whose extension is ".xlsx".
 
 ```bash
 $ ./cntblank --output-delimiter=, testdata/addrcode_jp.xlsx
@@ -50,74 +53,9 @@ seq,Name,#Blank,%Blank,MinLength,MaxLength,#Int,#Float,#Bool,#Time,Minimum,Maxim
 7,Column007,1788,1.0000,,,,,,,,,,
 ```
 
-## Full Usage
-
-`--help` shows the details.
-
-- Default input/output encoding is "UTF-8" and it also accepts only "sjis" value on the option.
-- Default input/output delimiter is TAB.
-- Meta-information is file path, field length, and number of records.
-- If no file path arguments are given, process standard input.
-- Also support JSON and HTML output.
-
-```text
-usage: cntblank [<flags>] [<tabfile>...]
-
-Count blank cells on text-based tabular data.
-
-Flags:
-      --help                   Show context-sensitive help (also try --help-long and --help-man).
-  -v, --verbose                Set verbose mode on.
-  -e, --input-encoding=INPUT-ENCODING
-                               Input encoding.
-  -E, --output-encoding=OUTPUT-ENCODING
-                               Output encoding.
-      --input-delimiter=INPUT-DELIMITER
-                               Input field delimiter.
-      --output-delimiter=OUTPUT-DELIMITER
-                               Output field delmiter.
-      --without-header         Tabular does not have header line.
-      --output-without-header  Output report does not have header line.
-      --strict                 Check column size strictly.
-      --sheet=SHEET            Excel sheet number which starts with 1.
-  -r, --recursive              Traverse directory recursively.
-      --output-meta            Put meta information.
-  -o, --output=OUTPUT          Output file.
-      --output-format=OUTPUT-FORMAT
-                               Output format.
-      --version                Show application version.
-
-Args:
-  [<tabfile>]  Tabular data files.
-```
-
-### Output fields
-
-| Name | Description |
-|------|-------------|
-| seq | Sequential number which starts with one. |
-| Name | Field name from first header line, otherwise "ColumnNNN" where NNN is sequential number. |
-| #Blank | Count of blank cells. |
-| %Blank | Percentage of blank cells. |
-| MinLength | Minimum length of valid cells. |
-| MaxLength | Maximum length of valid cells. |
-| #Int | Count of integer type cells. This may be blank. |
-| #Float | Count of float type cells. This may be blank. |
-| #Bool | Count of bool type cells. This may be blank. |
-| #Time | Count of time type cells. This may be blank. |
-| Minimum | Minimum value after guessing data type. |
-| Maximum | Maximum value after guessing data type. |
-| #True | Count of cells which should be treated as boolean true. |
-| #False | Count of cells which should be treated as boolean false. |
-
-Note that "1" is interpreted as boolean true and "0" is also interpreted as boolean false.
-Therefore, if a column is integer field, "#True" represents the count of "1" and "#False"
-represents the count of "0" in the field.
-Since some buggy data files sometimes include "0" as null accidentally, this feature may
-help you to count up pseudo blank cells.
-
-
 ## Development
+
+Requirements:
 
 - Golang 1.7
 - `gb` for build tool
@@ -144,6 +82,18 @@ $ gb vendor list
 $ make build
 ```
 
+*test* target calls `gb test`.
+
+```bash
+$ make test
+```
+
+*local* target runs program against under *testdata/* directory after building binary.
+
+```bash
+$ make local
+```
+
 To generate binary files for multiple architecture,
 simply run `make dist`.
 
@@ -152,10 +102,10 @@ simply run `make dist`.
 Packages to think about vendoring or reference:
 
 - [ImJasonH/csvstruct: Decode/encode CSV data into/from structs using reflection.](https://github.com/ImJasonH/csvstruct)
-- [guregu/null: reasonable handling of nullable values](https://github.com/guregu/null)
 - [lukasmartinelli/pgclimb: Export data from PostgreSQL into different data formats](https://github.com/lukasmartinelli/pgclimb)
 
 Tasks:
 
+- [x] Write results as Excel format
 - [ ] Parse whole sheets on Excel
-- [ ] Write results as Excel format
+- [ ] Guess field data type for SQL CREATE statement (CHAR, VARCHAR, NUMERIC, DATE, TIMESTAMP)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,3 @@
-[![Build Status](https://secure.travis-ci.org/skitazaki/cntblank.png?branch=master)](http://travis-ci.org/skitazaki/cntblank/tree/master)
-[![Build Status](https://secure.travis-ci.org/skitazaki/cntblank.png?branch=develop)](http://travis-ci.org/skitazaki/cntblank)
-
 # Count Blank Cells
 
 Count blank cells on text-based tabular data.
@@ -50,6 +47,41 @@ seq,Name,#Blank,%Blank,MinLength,MaxLength,#Int,#Float,#Bool,#Time,Minimum,Maxim
 7,Column007,1788,1.0000,,,,,,,,,,
 ```
 
+## Output
+
+It produces reports for each file in several formats.
+The report contains list of field summary in addition to file name and its checksum.
+Field summary is consists from field name and count of blanks, and data type indicator.
+
+Although default report format is CSV, you can specify `--output-format` option explicitly.
+Given `--output` option and its file extension is either of ".html", ".json", or ".xlsx", it automatically
+changes output format along with extension.
+
+### Output fields
+
+| Name | Description |
+|------|-------------|
+| seq | Sequential number which starts with one. |
+| Name | Field name from first header line, otherwise "ColumnNNN" where NNN is sequential number. |
+| #Blank | Count of blank cells. |
+| %Blank | Percentage of blank cells. |
+| MinLength | Minimum length of valid cells. |
+| MaxLength | Maximum length of valid cells. |
+| #Int | Count of integer type cells. This may be blank. |
+| #Float | Count of float type cells. This may be blank. |
+| #Bool | Count of bool type cells. This may be blank. |
+| #Time | Count of time type cells. This may be blank. |
+| Minimum | Minimum value after guessing data type. |
+| Maximum | Maximum value after guessing data type. |
+| #True | Count of cells which should be treated as boolean true. |
+| #False | Count of cells which should be treated as boolean false. |
+
+Note that "1" is interpreted as boolean true and "0" is also interpreted as boolean false.
+Therefore, if a column is integer field, "#True" represents the count of "1" and "#False"
+represents the count of "0" in the field.
+Since some buggy data files sometimes include "0" as null accidentally, this feature may
+help you to count up pseudo blank cells.
+
 ## Full Usage
 
 `--help` shows the details.
@@ -90,59 +122,3 @@ Flags:
 Args:
   [<tabfile>]  Tabular data files.
 ```
-
-### Output fields
-
-| Name | Description |
-|------|-------------|
-| seq | Sequential number which starts with one. |
-| Name | Field name from first header line, otherwise "ColumnNNN" where NNN is sequential number. |
-| #Blank | Count of blank cells. |
-| %Blank | Percentage of blank cells. |
-| MinLength | Minimum length of valid cells. |
-| MaxLength | Maximum length of valid cells. |
-| #Int | Count of integer type cells. This may be blank. |
-| #Float | Count of float type cells. This may be blank. |
-| #Bool | Count of bool type cells. This may be blank. |
-| #Time | Count of time type cells. This may be blank. |
-| Minimum | Minimum value after guessing data type. |
-| Maximum | Maximum value after guessing data type. |
-| #True | Count of cells which should be treated as boolean true. |
-| #False | Count of cells which should be treated as boolean false. |
-
-Note that "1" is interpreted as boolean true and "0" is also interpreted as boolean false.
-Therefore, if a column is integer field, "#True" represents the count of "1" and "#False"
-represents the count of "0" in the field.
-Since some buggy data files sometimes include "0" as null accidentally, this feature may
-help you to count up pseudo blank cells.
-
-
-## Development
-
-- Golang 1.7
-- `gb`
-
-### Setup and library dependency
-
-`Makefile` includes *setup* target calling `gb vendor restore`:
-
-```bash
-$ make setup
-```
-
-To see libraries:
-
-```bash
-$ gb vendor list
-```
-
-### Build
-
-*build* target calls `go fmt`, `go vet`, `goimports`, and `gb build`.
-
-```bash
-$ make build
-```
-
-To generate binary files for multiple architecture,
-simply run `make dist`.

--- a/src/cmd/cntblank/app.go
+++ b/src/cmd/cntblank/app.go
@@ -115,5 +115,8 @@ func newApplication(recursive bool, writer io.Writer, format string, dialect *cs
 		".xlsx",
 	})
 	a.writer = NewReportWriter(writer, f, dialect)
+	if a.writer == nil {
+		return nil, fmt.Errorf("no writer available")
+	}
 	return a, nil
 }

--- a/src/cmd/cntblank/app.go
+++ b/src/cmd/cntblank/app.go
@@ -13,7 +13,7 @@ import (
 type Application struct {
 	collector *FileCollector
 	reports   []Report
-	writer    *ReportWriter
+	writer    ReportWriter
 	logfields log.Fields
 }
 

--- a/src/cmd/cntblank/app.go
+++ b/src/cmd/cntblank/app.go
@@ -100,6 +100,13 @@ func (a *Application) putReport() error {
 
 // newApplication creates `Application` object to set some options.
 func newApplication(recursive bool, writer io.Writer, format string, dialect *csvhelper.FileDialect) (a *Application, err error) {
+	f := CSV // default output format is CSV
+	if format != "" {
+		f = formatFrom(format)
+		if f == Unknown {
+			return nil, fmt.Errorf("unknown format %q", format)
+		}
+	}
 	a = new(Application)
 	a.collector = newFileCollector(recursive, []string{
 		".csv",
@@ -107,6 +114,6 @@ func newApplication(recursive bool, writer io.Writer, format string, dialect *cs
 		".txt",
 		".xlsx",
 	})
-	a.writer = NewReportWriter(writer, format, dialect)
+	a.writer = NewReportWriter(writer, f, dialect)
 	return a, nil
 }

--- a/src/cmd/cntblank/format.go
+++ b/src/cmd/cntblank/format.go
@@ -42,10 +42,12 @@ func (f Format) String() string {
 }
 
 func formatFrom(s string) Format {
-	switch strings.ToLower(s) {
-	case "csv":
+	// Compare strings in lower case removing initial dot in case of
+	// given string is file extention.
+	switch strings.ToLower(strings.TrimPrefix(s, ".")) {
+	case "csv", "tsv", "txt":
 		return CSV
-	case "excel":
+	case "excel", "xlsx":
 		return Excel
 	case "json":
 		return JSON

--- a/src/cmd/cntblank/format.go
+++ b/src/cmd/cntblank/format.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"strings"
+)
+
+// Format represents file format.
+type Format int
+
+const (
+	// Unknown is nil value of Format type
+	Unknown Format = iota
+	// CSV is delimiter separated values
+	CSV
+	// Excel is Microsoft office suite
+	Excel
+	// JSON is JSON object
+	JSON
+	// Text is plain text format
+	Text
+	// HTML is HTML file format
+	HTML
+)
+
+func (f Format) String() string {
+	switch f {
+	case Unknown:
+		return "Unknown"
+	case CSV:
+		return "CSV"
+	case Excel:
+		return "Excel"
+	case JSON:
+		return "JSON"
+	case Text:
+		return "Text"
+	case HTML:
+		return "HTML"
+	default:
+		return "undefined"
+	}
+}
+
+func formatFrom(s string) Format {
+	switch strings.ToLower(s) {
+	case "csv":
+		return CSV
+	case "excel":
+		return Excel
+	case "json":
+		return JSON
+	case "text":
+		return Text
+	case "html":
+		return HTML
+	default:
+		return Unknown
+	}
+}

--- a/src/cmd/cntblank/format_test.go
+++ b/src/cmd/cntblank/format_test.go
@@ -30,10 +30,15 @@ func TestFormatFrom(t *testing.T) {
 	}{
 		{"CSV", CSV},
 		{"csv", CSV},
+		{".tsv", CSV},
+		{".txt", CSV},
 		{"Excel", Excel},
+		{"xlsx", Excel},
+		{".xlsx", Excel},
 		{"JSON", JSON},
 		{"Text", Text},
 		{"HTML", HTML},
+		{".xls", Unknown},
 	} {
 		a.Equal(tc.want, formatFrom(tc.str))
 	}

--- a/src/cmd/cntblank/format_test.go
+++ b/src/cmd/cntblank/format_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatString(t *testing.T) {
+	a := assert.New(t)
+	for _, tc := range []struct {
+		format Format
+		want   string
+	}{
+		{CSV, "CSV"},
+		{Excel, "Excel"},
+		{JSON, "JSON"},
+		{Text, "Text"},
+		{HTML, "HTML"},
+	} {
+		a.Equal(tc.want, tc.format.String())
+	}
+}
+
+func TestFormatFrom(t *testing.T) {
+	a := assert.New(t)
+	for _, tc := range []struct {
+		str  string
+		want Format
+	}{
+		{"CSV", CSV},
+		{"csv", CSV},
+		{"Excel", Excel},
+		{"JSON", JSON},
+		{"Text", Text},
+		{"HTML", HTML},
+	} {
+		a.Equal(tc.want, formatFrom(tc.str))
+	}
+}

--- a/src/cmd/cntblank/main.go
+++ b/src/cmd/cntblank/main.go
@@ -45,6 +45,8 @@ func main() {
 	// Set output stream.
 	var output io.Writer
 	if len(*cliOutput) > 0 {
+		// TODO: Check file name extension to detect output format automatically.
+		// If output-format option is empty, extract file extention.
 		fp, err := os.Create(*cliOutput)
 		if err != nil {
 			log.Fatal(err)

--- a/src/cmd/cntblank/main.go
+++ b/src/cmd/cntblank/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"io"
 	"os"
+	"path/filepath"
 
 	log "github.com/Sirupsen/logrus"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
@@ -42,11 +43,11 @@ func main() {
 	if *cliVerbose {
 		log.SetLevel(log.DebugLevel)
 	}
-	// Set output stream.
+	// Set output stream and output format.
 	var output io.Writer
-	if len(*cliOutput) > 0 {
-		// TODO: Check file name extension to detect output format automatically.
-		// If output-format option is empty, extract file extention.
+	var format string
+	format = *cliOutFormat
+	if *cliOutput != "" {
 		fp, err := os.Create(*cliOutput)
 		if err != nil {
 			log.Fatal(err)
@@ -54,12 +55,15 @@ func main() {
 		}
 		defer fp.Close()
 		output = fp
+		if format == "" {
+			format = filepath.Ext(*cliOutput)
+		}
 	} else {
 		output = os.Stdout
 	}
 	inDialect, outDialect := populateIODialect()
 	// Run main application logic.
-	app, err := newApplication(*cliRecursive, output, *cliOutFormat, outDialect)
+	app, err := newApplication(*cliRecursive, output, format, outDialect)
 	if err != nil {
 		log.Fatal(err)
 		return

--- a/src/cmd/cntblank/report.go
+++ b/src/cmd/cntblank/report.go
@@ -39,6 +39,25 @@ type ReportField struct {
 	fullWidth int
 }
 
+func (r ReportField) header() []string {
+	return []string{
+		"seq",
+		"Name",
+		"#Blank",
+		"%Blank",
+		"MinLength",
+		"MaxLength",
+		"#Int",
+		"#Float",
+		"#Bool",
+		"#Time",
+		"Minimum",
+		"Maximum",
+		"#True",
+		"#False",
+	}
+}
+
 func (r *ReportField) format(total int) []string {
 	s := make([]string, 14)
 	s[1] = r.Name

--- a/src/cmd/cntblank/report_test.go
+++ b/src/cmd/cntblank/report_test.go
@@ -241,3 +241,27 @@ func TestReportFieldFormat(t *testing.T) {
 		}
 	}
 }
+
+func TestReportFieldHeader(t *testing.T) {
+	a := assert.New(t)
+	header := ReportField{}.header()
+	a.Equal(14, len(header))
+	for i, s := range []string{
+		"seq",
+		"Name",
+		"#Blank",
+		"%Blank",
+		"MinLength",
+		"MaxLength",
+		"#Int",
+		"#Float",
+		"#Bool",
+		"#Time",
+		"Minimum",
+		"Maximum",
+		"#True",
+		"#False",
+	} {
+		a.Equal(s, header[i], "differ header[%d] index element", i)
+	}
+}

--- a/src/cmd/cntblank/writer.go
+++ b/src/cmd/cntblank/writer.go
@@ -35,12 +35,8 @@ type ReportHTMLWriter struct {
 }
 
 // NewReportWriter returns a new ReportWriter that writes to w by given format.
-func NewReportWriter(w io.Writer, format string, dialect *csvhelper.FileDialect) ReportWriter {
-	f := CSV // default format is CSV
-	if format != "" {
-		f = formatFrom(format)
-	}
-	switch f {
+func NewReportWriter(w io.Writer, format Format, dialect *csvhelper.FileDialect) ReportWriter {
+	switch format {
 	case CSV:
 		if dialect == nil {
 			dialect = &csvhelper.FileDialect{}

--- a/src/cmd/cntblank/writer.go
+++ b/src/cmd/cntblank/writer.go
@@ -6,46 +6,12 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"strings"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
 
 	"csvhelper"
 )
-
-// Format is output format
-type Format int
-
-const (
-	// Csv is delimiter separated values
-	Csv = iota + 1
-	// Excel is Microsoft office suite
-	Excel
-	// JSON is JSON object
-	JSON
-	// Text uses template
-	Text
-	// HTML uses template
-	HTML
-)
-
-func (s Format) String() string {
-	switch s {
-	case Csv:
-		return "CSV"
-	case Excel:
-		return "Excel"
-	case JSON:
-		return "JSON"
-	case Text:
-		return "Text"
-	case HTML:
-		return "HTML"
-	default:
-		return "Unknown"
-	}
-}
 
 // ReportOutputFields is a header line to write.
 var ReportOutputFields = []string{
@@ -77,20 +43,9 @@ func NewReportWriter(w io.Writer, format string, dialect *csvhelper.FileDialect)
 	if dialect == nil {
 		dialect = &csvhelper.FileDialect{}
 	}
-	var f Format
-	switch strings.ToLower(format) {
-	case "csv":
-		f = Csv
-	case "excel":
-		f = Excel
-	case "json":
-		f = JSON
-	case "text":
-		f = Text
-	case "html":
-		f = HTML
-	default:
-		f = Csv
+	f := CSV // default format is CSV
+	if format != "" {
+		f = formatFrom(format)
 	}
 	return &ReportWriter{
 		dialect: dialect,
@@ -101,7 +56,7 @@ func NewReportWriter(w io.Writer, format string, dialect *csvhelper.FileDialect)
 
 func (w *ReportWriter) Write(reports []Report) error {
 	switch w.format {
-	case Csv:
+	case CSV:
 		return w.writeCsv(reports)
 	case JSON:
 		return w.writeJSON(reports)

--- a/src/cmd/cntblank/writer.go
+++ b/src/cmd/cntblank/writer.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/tealeg/xlsx"
 
 	"csvhelper"
 )
@@ -34,6 +35,12 @@ type ReportHTMLWriter struct {
 	w io.Writer
 }
 
+// ReportExcelWriter is a writer object to write report as Excel format.
+type ReportExcelWriter struct {
+	w       io.Writer
+	dialect *csvhelper.FileDialect
+}
+
 // NewReportWriter returns a new ReportWriter that writes to w by given format.
 func NewReportWriter(w io.Writer, format Format, dialect *csvhelper.FileDialect) ReportWriter {
 	switch format {
@@ -42,6 +49,14 @@ func NewReportWriter(w io.Writer, format Format, dialect *csvhelper.FileDialect)
 			dialect = &csvhelper.FileDialect{}
 		}
 		return &ReportCSVWriter{
+			dialect: dialect,
+			w:       w,
+		}
+	case Excel:
+		if dialect == nil {
+			dialect = &csvhelper.FileDialect{}
+		}
+		return &ReportExcelWriter{
 			dialect: dialect,
 			w:       w,
 		}
@@ -160,4 +175,164 @@ func (w *ReportHTMLWriter) Write(reports []Report) error {
 		return err
 	}
 	return tmpl.Execute(w.w, reports)
+}
+
+func (w *ReportExcelWriter) Write(reports []Report) error {
+	file := xlsx.NewFile()
+	sheetFiles, err := file.AddSheet("Files")
+	if err != nil {
+		return err
+	}
+	sheetFields, err := file.AddSheet("Fields")
+	if err != nil {
+		return err
+	}
+	var row *xlsx.Row
+	// Put header line on Files sheet.
+	row = sheetFiles.AddRow()
+	for _, k := range []string{
+		"No.",
+		"Path",
+		"File name",
+		"MD5 Checksum",
+		"Has header",
+		"#Fields",
+		"#Records",
+	} {
+		w.addString(row, k)
+	}
+	// Put header line on Fields sheet.
+	row = sheetFields.AddRow()
+	for _, k := range []string{
+		"No.",
+		"Name",
+		"#Blank",
+		"%Blank",
+		"MinLength",
+		"MaxLength",
+		"#Int",
+		"#Float",
+		"#Bool",
+		"#Time",
+		"Minimum",
+		"Maximum",
+		"MinTime",
+		"MaxTime",
+		"#True",
+		"#False",
+	} {
+		w.addString(row, k)
+	}
+	for i, report := range reports {
+		log.Debugf("[%d] write report of %q (%s)", i+1, report.Path, report.MD5hex)
+		row = sheetFiles.AddRow()
+		w.addInt(row, i+1)
+		w.addString(row, report.Path)
+		w.addString(row, report.Filename)
+		w.addString(row, report.MD5hex)
+		w.addBool(row, report.HasHeader)
+		w.addInt(row, len(report.Fields))
+		w.addInt(row, report.Records)
+		if i > 0 {
+			// Append blank row to separate files
+			row = sheetFields.AddRow()
+			w.addString(row, "")
+		}
+		// Put preamble about meta-data
+		row = sheetFields.AddRow()
+		w.addString(row, fmt.Sprintf("# File No.%d", i+1))
+		w.addString(row, report.Filename)
+		w.addString(row, report.MD5hex)
+		row = sheetFields.AddRow()
+		w.addString(row, "# Contents")
+		if report.HasHeader {
+			w.addString(row, "has header")
+		} else {
+			w.addString(row, "does not have header")
+		}
+		w.addString(row, "")
+		w.addInt(row, len(report.Fields))
+		w.addString(row, "fields")
+		w.addString(row, "")
+		w.addInt(row, report.Records)
+		w.addString(row, "records")
+		w.writeFields(sheetFields, report.Fields, report.Records)
+	}
+	return file.Write(w.w)
+}
+
+func (w *ReportExcelWriter) writeFields(sheet *xlsx.Sheet, fields []*ReportField, total int) {
+	var row *xlsx.Row
+	for i, field := range fields {
+		row = sheet.AddRow()
+		w.addInt(row, i+1)
+		w.addString(row, field.Name)
+		w.addInt(row, field.Blank)
+		if total > 0 {
+			w.addFloat(row, float64(field.Blank)/float64(total))
+		} else {
+			w.addString(row, "N/A divided by 0")
+		}
+		w.addInt(row, field.MinLength)
+		w.addInt(row, field.MaxLength)
+		w.addInt(row, field.TypeInt)
+		w.addInt(row, field.TypeFloat)
+		w.addInt(row, field.TypeBool)
+		w.addInt(row, field.TypeTime)
+		if field.Minimum != nil {
+			w.addFloat(row, *field.Minimum)
+		} else {
+			w.addString(row, "")
+		}
+		if field.Maximum != nil {
+			w.addFloat(row, *field.Maximum)
+		} else {
+			w.addString(row, "")
+		}
+		if field.MinTime != nil {
+			w.addTime(row, *field.MinTime)
+		} else {
+			w.addString(row, "")
+		}
+		if field.MaxTime != nil {
+			w.addTime(row, *field.MaxTime)
+		} else {
+			w.addString(row, "")
+		}
+		if field.BoolTrue != nil {
+			w.addInt(row, *field.BoolTrue)
+		} else {
+			w.addString(row, "")
+		}
+		if field.BoolFalse != nil {
+			w.addInt(row, *field.BoolFalse)
+		} else {
+			w.addString(row, "")
+		}
+	}
+}
+
+func (w *ReportExcelWriter) addString(row *xlsx.Row, value string) {
+	cell := row.AddCell()
+	cell.SetString(value)
+}
+
+func (w *ReportExcelWriter) addBool(row *xlsx.Row, value bool) {
+	cell := row.AddCell()
+	cell.SetBool(value)
+}
+
+func (w *ReportExcelWriter) addInt(row *xlsx.Row, value int) {
+	cell := row.AddCell()
+	cell.SetInt(value)
+}
+
+func (w *ReportExcelWriter) addFloat(row *xlsx.Row, value float64) {
+	cell := row.AddCell()
+	cell.SetFloat(value)
+}
+
+func (w *ReportExcelWriter) addTime(row *xlsx.Row, value time.Time) {
+	cell := row.AddCell()
+	cell.SetDateTime(value)
 }

--- a/src/cmd/cntblank/writer.go
+++ b/src/cmd/cntblank/writer.go
@@ -13,24 +13,6 @@ import (
 	"csvhelper"
 )
 
-// ReportOutputFields is a header line to write.
-var ReportOutputFields = []string{
-	"seq",
-	"Name",
-	"#Blank",
-	"%Blank",
-	"MinLength",
-	"MaxLength",
-	"#Int",
-	"#Float",
-	"#Bool",
-	"#Time",
-	"Minimum",
-	"Maximum",
-	"#True",
-	"#False",
-}
-
 // ReportWriter is a writer object to wrap csv writer.
 type ReportWriter struct {
 	dialect *csvhelper.FileDialect
@@ -106,7 +88,7 @@ func (w *ReportWriter) writeCsvOne(writer *csv.Writer, report Report) error {
 	}
 	// Put header line.
 	if w.dialect.HasHeader {
-		writer.Write(ReportOutputFields)
+		writer.Write(ReportField{}.header())
 	}
 	// Put each field report.
 	for i, f := range report.Fields {

--- a/src/cmd/cntblank/writer_test.go
+++ b/src/cmd/cntblank/writer_test.go
@@ -9,10 +9,22 @@ import (
 	"csvhelper"
 )
 
+func TestNewReportWriter(t *testing.T) {
+	a := assert.New(t)
+	w := NewReportWriter(nil, 0, nil)
+	a.Nil(w)
+	w = NewReportWriter(nil, CSV, nil)
+	a.NotNil(w)
+	w = NewReportWriter(nil, JSON, nil)
+	a.NotNil(w)
+	w = NewReportWriter(nil, HTML, nil)
+	a.NotNil(w)
+}
+
 func TestReportWriterWithHeader(t *testing.T) {
 	buffer := &bytes.Buffer{}
 	dialect, err := csvhelper.NewFileDialect("", "", true)
-	w := NewReportWriter(buffer, "", dialect)
+	w := NewReportWriter(buffer, CSV, dialect)
 	s := make([]Report, 1)
 	s[0] = Report{}
 	err = w.Write(s)
@@ -30,7 +42,7 @@ func TestReportWriterWithMetadata(t *testing.T) {
 	buffer := &bytes.Buffer{}
 	dialect, err := csvhelper.NewFileDialect("", "", true)
 	dialect.HasMetadata = true
-	w := NewReportWriter(buffer, "", dialect)
+	w := NewReportWriter(buffer, CSV, dialect)
 	s := make([]Report, 1)
 	s[0] = Report{}
 	err = w.Write(s)
@@ -48,7 +60,7 @@ func TestReportWriterWithMetadata(t *testing.T) {
 
 func TestReportWriterWithoutMetadata(t *testing.T) {
 	buffer := &bytes.Buffer{}
-	w := NewReportWriter(buffer, "", nil)
+	w := NewReportWriter(buffer, CSV, nil)
 	s := make([]Report, 1)
 	s[0] = Report{}
 	err := w.Write(s)
@@ -66,7 +78,7 @@ func TestReportWriter_JSON(t *testing.T) {
 	expected := `[{"header":false,"records":0,"fields":null}]`
 	a := assert.New(t)
 	buffer := &bytes.Buffer{}
-	w := NewReportWriter(buffer, "json", nil)
+	w := NewReportWriter(buffer, JSON, nil)
 	s := make([]Report, 1)
 	s[0] = Report{}
 	err := w.Write(s)

--- a/src/cmd/cntblank/writer_test.go
+++ b/src/cmd/cntblank/writer_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"csvhelper"
 )
 
@@ -58,4 +60,16 @@ func TestReportWriterWithoutMetadata(t *testing.T) {
 	if out != expected {
 		t.Errorf("out=%q want %q", out, expected)
 	}
+}
+
+func TestReportWriter_JSON(t *testing.T) {
+	expected := `[{"header":false,"records":0,"fields":null}]`
+	a := assert.New(t)
+	buffer := &bytes.Buffer{}
+	w := NewReportWriter(buffer, "json", nil)
+	s := make([]Report, 1)
+	s[0] = Report{}
+	err := w.Write(s)
+	a.Nil(err)
+	a.Equal(expected, buffer.String())
 }

--- a/src/cmd/cntblank/writer_test.go
+++ b/src/cmd/cntblank/writer_test.go
@@ -19,6 +19,8 @@ func TestNewReportWriter(t *testing.T) {
 	a.NotNil(w)
 	w = NewReportWriter(nil, HTML, nil)
 	a.NotNil(w)
+	w = NewReportWriter(nil, Excel, nil)
+	a.NotNil(w)
 }
 
 func TestReportWriterWithHeader(t *testing.T) {


### PR DESCRIPTION
If output file name extension is ".xlsx", it writes reports as Microsoft Excel file.
Results file contains contains cover sheet to list processed files, which is same with monitor output.